### PR TITLE
⚡️ Commit from Jolt AI ⚡️Adds blocked directive

### DIFF
--- a/api/src/directives/blocked/blocked.test.ts
+++ b/api/src/directives/blocked/blocked.test.ts
@@ -1,0 +1,23 @@
+import { mockRedwoodDirective, getDirectiveName } from '@redwoodjs/testing/api'
+import { AuthenticationError } from '@redwoodjs/graphql-server'
+
+import blocked from './blocked'
+
+describe('blocked directive', () => {
+  it('declares the directive sdl as schema, with the correct name', () => {
+    expect(blocked.schema).toBeTruthy()
+    expect(getDirectiveName(blocked.schema)).toBe('blocked')
+  })
+
+  it('blocked throws an AuthenticationError', () => {
+    const mockExecution = mockRedwoodDirective(blocked, { context: {} })
+
+    expect(mockExecution).toThrow(AuthenticationError)
+    expect(mockExecution).toThrow(
+      'You are not authorized to access this resource'
+    )
+  })
+})
+
+// This test file was generated for the blocked directive.
+// You may want to add more specific tests as needed.

--- a/api/src/directives/blocked/blocked.ts
+++ b/api/src/directives/blocked/blocked.ts
@@ -1,0 +1,31 @@
+import {
+  AuthenticationError,
+  createValidatorDirective,
+  ValidatorDirectiveFunc,
+} from '@redwoodjs/graphql-server'
+
+import { logger } from 'src/lib/logger'
+
+export const schema = gql`
+  """
+  Use @blocked to validate access to a field, query or mutation.
+  """
+  directive @blocked on FIELD_DEFINITION
+`
+
+const validate: ValidatorDirectiveFunc = ({ directiveArgs }) => {
+  logger.warn(
+    {
+      directiveArgs,
+    },
+    'Blocked directive called'
+  )
+
+  throw new AuthenticationError(
+    'You are not authorized to access this resource'
+  )
+}
+
+const blocked = createValidatorDirective(schema, validate)
+
+export default blocked

--- a/api/src/graphql/artists.sdl.ts
+++ b/api/src/graphql/artists.sdl.ts
@@ -8,8 +8,8 @@ export const schema = gql`
   }
 
   type Query {
-    artists: [Artist!]! @requireAuth
-    artist(id: Int!): Artist @requireAuth
+    artists: [Artist!]! @blocked
+    artist(id: Int!): Artist @blocked
   }
 
   input CreateArtistInput {
@@ -21,8 +21,8 @@ export const schema = gql`
   }
 
   type Mutation {
-    createArtist(input: CreateArtistInput!): Artist! @requireAuth
-    updateArtist(id: Int!, input: UpdateArtistInput!): Artist! @requireAuth
-    deleteArtist(id: Int!): Artist! @requireAuth
+    createArtist(input: CreateArtistInput!): Artist! @blocked
+    updateArtist(id: Int!, input: UpdateArtistInput!): Artist! @blocked
+    deleteArtist(id: Int!): Artist! @blocked
   }
 `

--- a/api/src/graphql/genres.sdl.ts
+++ b/api/src/graphql/genres.sdl.ts
@@ -6,8 +6,8 @@ export const schema = gql`
   }
 
   type Query {
-    genres: [Genre!]! @requireAuth
-    genre(id: Int!): Genre @requireAuth
+    genres: [Genre!]! @blocked
+    genre(id: Int!): Genre @blocked
   }
 
   input CreateGenreInput {
@@ -19,8 +19,8 @@ export const schema = gql`
   }
 
   type Mutation {
-    createGenre(input: CreateGenreInput!): Genre! @requireAuth
-    updateGenre(id: Int!, input: UpdateGenreInput!): Genre! @requireAuth
-    deleteGenre(id: Int!): Genre! @requireAuth
+    createGenre(input: CreateGenreInput!): Genre! @blocked
+    updateGenre(id: Int!, input: UpdateGenreInput!): Genre! @blocked
+    deleteGenre(id: Int!): Genre! @blocked
   }
 `

--- a/api/src/graphql/images.sdl.ts
+++ b/api/src/graphql/images.sdl.ts
@@ -14,8 +14,8 @@ export const schema = gql`
   }
 
   type Query {
-    images: [Image!]! @requireAuth
-    image(id: Int!): Image @requireAuth
+    images: [Image!]! @blocked
+    image(id: Int!): Image @blocked
   }
 
   input CreateImageInput {
@@ -39,8 +39,8 @@ export const schema = gql`
   }
 
   type Mutation {
-    createImage(input: CreateImageInput!): Image! @requireAuth
-    updateImage(id: Int!, input: UpdateImageInput!): Image! @requireAuth
-    deleteImage(id: Int!): Image! @requireAuth
+    createImage(input: CreateImageInput!): Image! @blocked
+    updateImage(id: Int!, input: UpdateImageInput!): Image! @blocked
+    deleteImage(id: Int!): Image! @blocked
   }
 `

--- a/api/src/graphql/labels.sdl.ts
+++ b/api/src/graphql/labels.sdl.ts
@@ -9,8 +9,8 @@ export const schema = gql`
   }
 
   type Query {
-    labels: [Label!]! @requireAuth
-    label(id: Int!): Label @requireAuth
+    labels: [Label!]! @blocked
+    label(id: Int!): Label @blocked
   }
 
   input CreateLabelInput {
@@ -24,8 +24,8 @@ export const schema = gql`
   }
 
   type Mutation {
-    createLabel(input: CreateLabelInput!): Label! @requireAuth
-    updateLabel(id: Int!, input: UpdateLabelInput!): Label! @requireAuth
-    deleteLabel(id: Int!): Label! @requireAuth
+    createLabel(input: CreateLabelInput!): Label! @blocked
+    updateLabel(id: Int!, input: UpdateLabelInput!): Label! @blocked
+    deleteLabel(id: Int!): Label! @blocked
   }
 `

--- a/api/src/graphql/releases.sdl.ts
+++ b/api/src/graphql/releases.sdl.ts
@@ -25,8 +25,8 @@ export const schema = gql`
   }
 
   type Query {
-    releases: [Release!]! @requireAuth
-    release(id: Int!): Release @requireAuth
+    releases: [Release!]! @blocked
+    release(id: Int!): Release @blocked
   }
 
   input CreateReleaseInput {
@@ -64,8 +64,8 @@ export const schema = gql`
   }
 
   type Mutation {
-    createRelease(input: CreateReleaseInput!): Release! @requireAuth
-    updateRelease(id: Int!, input: UpdateReleaseInput!): Release! @requireAuth
-    deleteRelease(id: Int!): Release! @requireAuth
+    createRelease(input: CreateReleaseInput!): Release! @blocked
+    updateRelease(id: Int!, input: UpdateReleaseInput!): Release! @blocked
+    deleteRelease(id: Int!): Release! @blocked
   }
 `

--- a/api/src/graphql/styles.sdl.ts
+++ b/api/src/graphql/styles.sdl.ts
@@ -6,8 +6,8 @@ export const schema = gql`
   }
 
   type Query {
-    styles: [Style!]! @requireAuth
-    style(id: Int!): Style @requireAuth
+    styles: [Style!]! @blocked
+    style(id: Int!): Style @blocked
   }
 
   input CreateStyleInput {
@@ -19,8 +19,8 @@ export const schema = gql`
   }
 
   type Mutation {
-    createStyle(input: CreateStyleInput!): Style! @requireAuth
-    updateStyle(id: Int!, input: UpdateStyleInput!): Style! @requireAuth
-    deleteStyle(id: Int!): Style! @requireAuth
+    createStyle(input: CreateStyleInput!): Style! @blocked
+    updateStyle(id: Int!, input: UpdateStyleInput!): Style! @blocked
+    deleteStyle(id: Int!): Style! @blocked
   }
 `


### PR DESCRIPTION
This commit was made by Jolt AI (https://jolt.multiple.dev)

Implement blocked GraphQL directive (https://jolt.multiple.dev/tasks/70085719-7f40-4a4c-9b84-471d8c0f7797)

Description:
Let's secure the graphql api with a redwoodJS directive called blocked.

```
import {
  AuthenticationError,
  createValidatorDirective,
  ValidatorDirectiveFunc,
} from '@redwoodjs/graphql-server'

import { logger } from 'src/lib/logger'

export const schema = gql`
  """
  Use @blocked to validate access to a field, query or mutation.
  """
  directive @blocked on FIELD_DEFINITION
`

const validate: ValidatorDirectiveFunc = ({ directiveArgs }) => {
  logger.warn(
    {
      directiveArgs,
    },
    'Blocked directive called'
  )

  throw new AuthenticationError(
    'You are not authorized to access this resource'
  )
}

const blocked = createValidatorDirective(schema, validate)

export default blocked
```

Create the directive above in `api/src/directives/blocked` and set all graphql operations that are requireAuth to use blocked instead.